### PR TITLE
Dynamically set alarm thresholds

### DIFF
--- a/alarms.yml
+++ b/alarms.yml
@@ -1,14 +1,16 @@
 loadaverage:
-  AlarmDescription: Load Average 8 or above. Runbook https://dewey.ft.com/upp-neo4j-cluster.html.
+  AlarmDescription: Load Average equal to number of cores or above. Runbook https://dewey.ft.com/upp-neo4j-cluster.html.
   MetricName: load.load
-  Threshold: ${LOAD_THRESHOLD}
+  # threshold is set dynamically at container startup by run.sh
+  Threshold: LOAD_THRESHOLD
   Statistic: Average
   ComparisonOperator: GreaterThanOrEqualToThreshold
   PluginInstance: NONE
 memory:
-  AlarmDescription: Memory usage high 55/61GB. Runbook https://dewey.ft.com/upp-neo4j-cluster.html.
+  AlarmDescription: Memory usage higher than 90%. Runbook https://dewey.ft.com/upp-neo4j-cluster.html.
   MetricName: memory.memory.used
-  Threshold: ${MEMORY_THRESHOLD}  
+  # threshold is set dynamically at container startup by run.sh
+  Threshold: MEMORY_THRESHOLD  
   Statistic: Average
   ComparisonOperator: GreaterThanOrEqualToThreshold
   PluginInstance: NONE

--- a/alarms.yml
+++ b/alarms.yml
@@ -1,14 +1,14 @@
 loadaverage:
   AlarmDescription: Load Average 8 or above. Runbook https://dewey.ft.com/upp-neo4j-cluster.html.
   MetricName: load.load
-  Threshold: 8
+  Threshold: ${LOAD_THRESHOLD}
   Statistic: Average
   ComparisonOperator: GreaterThanOrEqualToThreshold
   PluginInstance: NONE
 memory:
   AlarmDescription: Memory usage high 55/61GB. Runbook https://dewey.ft.com/upp-neo4j-cluster.html.
   MetricName: memory.memory.used
-  Threshold: 59055800320  
+  Threshold: ${MEMORY_THRESHOLD}  
   Statistic: Average
   ComparisonOperator: GreaterThanOrEqualToThreshold
   PluginInstance: NONE

--- a/alarms.yml
+++ b/alarms.yml
@@ -10,7 +10,7 @@ memory:
   AlarmDescription: Memory usage higher than 90%. Runbook https://dewey.ft.com/upp-neo4j-cluster.html.
   MetricName: memory.memory.used
   # threshold is set dynamically at container startup by run.sh
-  Threshold: MEMORY_THRESHOLD  
+  Threshold: MEMORY_THRESHOLD
   Statistic: Average
   ComparisonOperator: GreaterThanOrEqualToThreshold
   PluginInstance: NONE

--- a/run.sh
+++ b/run.sh
@@ -27,12 +27,12 @@ fi
 
 # Set the LOAD_THRESHOLD dynamically at startup
 LOAD_THRESHOLD=$(grep -c ^processor /proc/cpuinfo)
-sed -i "s/LOAD_THRESHOLD/${LOAD_THRESHOLD}" alarms.yml
+sed -i "s/LOAD_THRESHOLD/${LOAD_THRESHOLD}/g" alarms.yml
 
 # Set the MEMORY_THRESHOLD dynamically at startup
 MAX_MEMORY=$(( $(awk '/MemTotal/{print $2}' /proc/meminfo) * 1024 ))
 MEMORY_THRESHOLD=$(( ${MAX_MEMORY} * 90 / 100 ))
-sed -i "s/MEMORY_THRESHOLD/${MEMORY_THRESHOLD}" alarms.yml
+sed -i "s/MEMORY_THRESHOLD/${MEMORY_THRESHOLD}/g" alarms.yml
 
 # Create alarms
 /collective/cloudwatch-alarms/put_metric_alarm.py --namespace ${NAMESPACE} --instanceid ${INSTANCEID} ${OPTIONAL_ARGS}

--- a/run.sh
+++ b/run.sh
@@ -25,6 +25,15 @@ if [[ ! -z "${CONFIG}" ]]; then
   OPTIONAL_ARGS+=" "
 fi
 
+# Set the LOAD_THRESHOLD dynamically at startup
+LOAD_THRESHOLD=$(grep -c ^processor /proc/cpuinfo)
+sed -i "s/LOAD_THRESHOLD/${LOAD_THRESHOLD}" alarms.yml
+
+# Set the MEMORY_THRESHOLD dynamically at startup
+MAX_MEMORY=$(( $(awk '/MemTotal/{print $2}' /proc/meminfo) * 1024 ))
+MEMORY_THRESHOLD=$(( ${MAX_MEMORY} * 90 / 100 ))
+sed -i "s/MEMORY_THRESHOLD/${MEMORY_THRESHOLD}" alarms.yml
+
 # Create alarms
 /collective/cloudwatch-alarms/put_metric_alarm.py --namespace ${NAMESPACE} --instanceid ${INSTANCEID} ${OPTIONAL_ARGS}
 


### PR DESCRIPTION
To cope better with variable instance sizes.

The container now sets:
- load threshold equal to the number of cores
- memory threshold equal to 90% of total memory