### PR TITLE
Dynamically set alarm thresholds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ MAINTAINER 'Jussi Heinonen<jussi.heinonen@ft.com>'
 
 ADD etc/collectd.d /etc/collectd.d/
 ADD opt/collectd-plugins /opt/collectd-plugins/
-ADD alarms.yml /
-ADD run.sh /
 
 # Install dependencies
 RUN apk add -U linux-headers bash bash-doc bash-completion curl git \
@@ -24,6 +22,8 @@ RUN curl https://collectd.org/files/collectd-5.7.1.tar.bz2 | tar xjf - &&\
    make clean &&\
    echo 'Include "/etc/collectd.d"' > /etc/collectd/collectd.conf
 
+ADD alarms.yml /
+ADD run.sh /
 
 # Clean
 #RUN rm -rf /var/cache/apk/*

--- a/alarms.yml
+++ b/alarms.yml
@@ -6,6 +6,9 @@ loadaverage:
   Statistic: Average
   ComparisonOperator: GreaterThanOrEqualToThreshold
   PluginInstance: NONE
+  Dimensions:
+    - Name: InstanceId
+      Value:  get_instanceid()
 memory:
   AlarmDescription: Memory usage higher than 90%. Runbook https://dewey.ft.com/upp-neo4j-cluster.html.
   MetricName: memory.memory.used
@@ -14,6 +17,9 @@ memory:
   Statistic: Average
   ComparisonOperator: GreaterThanOrEqualToThreshold
   PluginInstance: NONE
+  Dimensions:
+    - Name: InstanceId
+      Value:  get_instanceid()
 disk.root:
   AlarmDescription: Root partition 90% full. Runbook https://dewey.ft.com/upp-neo4j-cluster.html.
   MetricName: df.percent_bytes.used
@@ -21,6 +27,9 @@ disk.root:
   Statistic: Average
   ComparisonOperator: GreaterThanOrEqualToThreshold
   PluginInstance: root
+  Dimensions:
+    - Name: InstanceId
+      Value:  get_instanceid()
 disk.vol.neo4j:
   AlarmDescription: /vol/neo4j partition 90% full. Runbook https://dewey.ft.com/upp-neo4j-cluster.html.
   MetricName: df.percent_bytes.used
@@ -28,3 +37,6 @@ disk.vol.neo4j:
   Statistic: Average
   ComparisonOperator: GreaterThanOrEqualToThreshold
   PluginInstance: vol-neo4j
+  Dimensions:
+    - Name: InstanceId
+      Value:  get_instanceid()


### PR DESCRIPTION
- Re-order Dockerfile to re-use image layers between builds
- Add dimensions (now required by `put_metric_alarm.py`)